### PR TITLE
Do not require T: Ord when a custom comparator is provided

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -469,7 +469,7 @@ impl<T: Ord> BinaryHeap<T, MinComparator> {
     }
 }
 
-impl<T: Ord, F> BinaryHeap<T, FnComparator<F>> 
+impl<T, F> BinaryHeap<T, FnComparator<F>> 
 where F: Clone + FnMut(&T, &T) -> Ordering,
 {
     /// Creates an empty `BinaryHeap`. 


### PR DESCRIPTION
`BinaryHeap::new_by` and `BinaryHeap::with_capacity_by` require `T: Ord` while it is not needed. This just remove the constraint so we can we custom comparators with types that do not implement Ord.