### PR TITLE
Add BinaryHeap::from_vec_cmp_rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* generic constructor `from_vec_cmp_raw()`.
+
 ## [0.3.0] - 2020-07-08
 
 ### Added

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -394,8 +394,18 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     /// Because `BinaryHeap` stores the elements in its internal `Vec`,
     /// it's natural to construct it from `Vec`.
     pub fn from_vec_cmp(vec: Vec<T>, cmp: C) -> Self {
+        BinaryHeap::from_vec_cmp_rebuild(vec, cmp, true)
+    }
+
+    /// Generic constructor for `BinaryHeap` from `Vec` and comparator.
+    ///
+    /// Because `BinaryHeap` stores the elements in its internal `Vec`,
+    /// it's natural to construct it from `Vec`.
+    pub fn from_vec_cmp_rebuild(vec: Vec<T>, cmp: C, rebuild: bool) -> Self {
         let mut heap = BinaryHeap { data: vec, cmp };
-        heap.rebuild();
+        if rebuild && !heap.data.is_empty() {
+            heap.rebuild();
+        }
         heap
     }
 }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -394,7 +394,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     /// Because `BinaryHeap` stores the elements in its internal `Vec`,
     /// it's natural to construct it from `Vec`.
     pub fn from_vec_cmp(vec: Vec<T>, cmp: C) -> Self {
-        unsafe { BinaryHeap::from_vec_cmp_rebuild(vec, cmp, true) }
+        unsafe { BinaryHeap::from_vec_cmp_raw(vec, cmp, true) }
     }
 
     /// Generic constructor for `BinaryHeap` from `Vec` and comparator.
@@ -404,7 +404,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     ///
     /// # Safety
     /// User is responsible for providing valid `rebuild` value.
-    pub unsafe fn from_vec_cmp_rebuild(vec: Vec<T>, cmp: C, rebuild: bool) -> Self {
+    pub unsafe fn from_vec_cmp_raw(vec: Vec<T>, cmp: C, rebuild: bool) -> Self {
         let mut heap = BinaryHeap { data: vec, cmp };
         if rebuild && !heap.data.is_empty() {
             heap.rebuild();

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -394,14 +394,17 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     /// Because `BinaryHeap` stores the elements in its internal `Vec`,
     /// it's natural to construct it from `Vec`.
     pub fn from_vec_cmp(vec: Vec<T>, cmp: C) -> Self {
-        BinaryHeap::from_vec_cmp_rebuild(vec, cmp, true)
+        unsafe { BinaryHeap::from_vec_cmp_rebuild(vec, cmp, true) }
     }
 
     /// Generic constructor for `BinaryHeap` from `Vec` and comparator.
     ///
     /// Because `BinaryHeap` stores the elements in its internal `Vec`,
     /// it's natural to construct it from `Vec`.
-    pub fn from_vec_cmp_rebuild(vec: Vec<T>, cmp: C, rebuild: bool) -> Self {
+    ///
+    /// # Safety
+    /// User is responsible for providing valid `rebuild` value.
+    pub unsafe fn from_vec_cmp_rebuild(vec: Vec<T>, cmp: C, rebuild: bool) -> Self {
         let mut heap = BinaryHeap { data: vec, cmp };
         if rebuild && !heap.data.is_empty() {
             heap.rebuild();


### PR DESCRIPTION
In some cases, if the vec has satisfied the comparator, it's no need to rebuild. So we can improve performance by set `rebuild` as `false`.