### PR TITLE
Ignore IDEA and VSCode project dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-
+.idea
+.vscode
 /target/
 **/*.rs.bk
 Cargo.lock


### PR DESCRIPTION
Intellij IDEA/CLion and VS Code are popular IDE for Rust development, ignore these project directories.