### PR TITLE
Fix clippy warning

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -155,6 +155,7 @@
 //! }
 //! ```
 
+#![allow(clippy::needless_doctest_main)]
 #![allow(missing_docs)]
 // #![stable(feature = "rust1", since = "1.0.0")]
 


### PR DESCRIPTION
```
warning: needless `fn main` in doctest
  --> src/binary_heap.rs:34:4
   |
34 | //! use std::cmp::Ordering;
   |    ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(clippy::needless_doctest_main)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_doctest_main
```