### PR TITLE
Avoid sift_down for unmutated PeekMut (rust#75974)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         - macos-latest
         rust:
         - stable
-        - 1.31.1 # MSRV (Rust 2018)
+        - 1.32.0 # MSRV (Rust 2018 and rand support)
         cargo_args:
         - ""
         - --features serde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Bump MSRV (minimum supported rust version) to rust 1.32.0.
+
 ## [0.3.1] - 2020-09-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.116", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.57"
+rand = "0.7.3"
 
 [badges]
 # TODO: waiting for PR to land...: https://github.com/rust-lang/crates.io/pull/1838#

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Other notable added methods are:
 
 ## MSRV (Minimum Supported Rust Version)
 
-This crate requires Rust 1.31.1 or later.
+This crate requires Rust 1.32.0 or later.
 
 # Changes
 

--- a/benches/binary_heap.rs
+++ b/benches/binary_heap.rs
@@ -1,0 +1,95 @@
+#![feature(test)]
+
+extern crate test;
+
+use binary_heap_plus::BinaryHeap;
+
+use rand::{seq::SliceRandom, thread_rng};
+use test::{black_box, Bencher};
+
+#[bench]
+fn bench_find_smallest_1000(b: &mut Bencher) {
+    let mut rng = thread_rng();
+    let mut vec: Vec<u32> = (0..100_000).collect();
+    vec.shuffle(&mut rng);
+
+    b.iter(|| {
+        let mut iter = vec.iter().copied();
+        let mut heap: BinaryHeap<_> = iter.by_ref().take(1000).collect();
+
+        for x in iter {
+            let mut max = heap.peek_mut().unwrap();
+            // This comparison should be true only 1% of the time.
+            // Unnecessary `sift_down`s will degrade performance
+            if x < *max {
+                *max = x;
+            }
+        }
+
+        heap
+    })
+}
+
+#[bench]
+fn bench_peek_mut_deref_mut(b: &mut Bencher) {
+    let mut bheap = BinaryHeap::from(vec![42]);
+    let vec: Vec<u32> = (0..1_000_000).collect();
+
+    b.iter(|| {
+        let vec = black_box(&vec);
+        let mut peek_mut = bheap.peek_mut().unwrap();
+        // The compiler shouldn't be able to optimize away the `sift_down`
+        // assignment in `PeekMut`'s `DerefMut` implementation since
+        // the loop may not run.
+        for &i in vec.iter() {
+            *peek_mut = i;
+        }
+        // Remove the already minimal overhead of the sift_down
+        std::mem::forget(peek_mut);
+    })
+}
+
+#[bench]
+fn bench_from_vec(b: &mut Bencher) {
+    let mut rng = thread_rng();
+    let mut vec: Vec<u32> = (0..100_000).collect();
+    vec.shuffle(&mut rng);
+
+    b.iter(|| BinaryHeap::from(vec.clone()))
+}
+
+#[bench]
+fn bench_into_sorted_vec(b: &mut Bencher) {
+    let bheap: BinaryHeap<i32> = (0..10_000).collect();
+
+    b.iter(|| bheap.clone().into_sorted_vec())
+}
+
+#[bench]
+fn bench_push(b: &mut Bencher) {
+    let mut bheap = BinaryHeap::with_capacity(50_000);
+    let mut rng = thread_rng();
+    let mut vec: Vec<u32> = (0..50_000).collect();
+    vec.shuffle(&mut rng);
+
+    b.iter(|| {
+        for &i in vec.iter() {
+            bheap.push(i);
+        }
+        black_box(&mut bheap);
+        bheap.clear();
+    })
+}
+
+#[bench]
+fn bench_pop(b: &mut Bencher) {
+    let mut bheap = BinaryHeap::with_capacity(10_000);
+
+    b.iter(|| {
+        bheap.extend((0..10_000).rev());
+        black_box(&mut bheap);
+        while let Some(elem) = bheap.pop() {
+            black_box(elem);
+        }
+    })
+}

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -335,6 +335,7 @@ impl<'a, T, C: Compare<T>> Deref for PeekMut<'a, T, C> {
 // #[stable(feature = "binary_heap_peek_mut", since = "1.12.0")]
 impl<'a, T, C: Compare<T>> DerefMut for PeekMut<'a, T, C> {
     fn deref_mut(&mut self) -> &mut T {
+        self.sift = true;
         &mut self.heap.data[0]
     }
 }
@@ -751,7 +752,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
         } else {
             Some(PeekMut {
                 heap: self,
-                sift: true,
+                sift: false,
             })
         }
     }


### PR DESCRIPTION
This ports the change from rust-lang/rust#75974 -- `PeekMut` is now constructed with `sift: false`, and it is only set `true` by `DerefMut`. The same benchmarks are included this PR, and here are my results on this crate:

```
 name                      bench.master ns/iter  bench.75974 ns/iter  diff ns/iter   diff %  speedup
 bench_find_smallest_1000  358,162               240,945                  -117,217  -32.73%   x 1.49
 bench_from_vec            519,992               519,116                      -876   -0.17%   x 1.00
 bench_into_sorted_vec     336,279               309,787                   -26,492   -7.88%   x 1.09
 bench_peek_mut_deref_mut  457,992               1,117,506                 659,514  144.00%   x 0.41
 bench_pop                 364,764               360,842                    -3,922   -1.08%   x 1.01
 bench_push                487,726               483,631                    -4,095   -0.84%   x 1.01
```

So `bench_find_smallest_1000` is much improved, while `bench_peek_mut_deref_mut` is much worse, just as they found in the standard library. The latter was justified as being "highly artificial" in https://github.com/rust-lang/rust/pull/75974#pullrequestreview-492011705.