### PR TITLE
Enable bench (#29)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,12 +15,15 @@ jobs:
         - windows-latest
         - macos-latest
         rust:
-        - nightly
         - stable
         - 1.32.0 # MSRV (Rust 2018 and rand support)
         cargo_args:
         - ""
         - --features serde
+        include:
+          - os: ubuntu-latest
+            rust: nightly
+            cargo_args: ""
 
     runs-on: ${{ matrix.os }}
 
@@ -53,7 +56,7 @@ jobs:
 
     - name: Run cargo bench
       uses: actions-rs/cargo@v1
-      if: ${{ matrix.rust == 'nightly' && matrix.os == 'ubuntu-latest' && matrix.cargo_args == '' }}
+      if: ${{ matrix.rust == 'nightly' }}
       with:
         command: bench
         args: ${{ matrix.cargo_args }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,6 +53,7 @@ jobs:
 
     - name: Run cargo bench
       uses: actions-rs/cargo@v1
+      if: ${{ matrix.rust == 'nightly' }}
       with:
         command: bench
         args: ${{ matrix.cargo_args }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,7 @@ jobs:
         - windows-latest
         - macos-latest
         rust:
+        - nightly
         - stable
         - 1.32.0 # MSRV (Rust 2018 and rand support)
         cargo_args:
@@ -50,10 +51,10 @@ jobs:
         command: test
         args: ${{ matrix.cargo_args }}
 
-    - name: Run cargo test
+    - name: Run cargo bench
       uses: actions-rs/cargo@v1
       with:
-        command: test
+        command: bench
         args: ${{ matrix.cargo_args }}
 
 #     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,12 @@ jobs:
         command: test
         args: ${{ matrix.cargo_args }}
 
+    - name: Run cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: ${{ matrix.cargo_args }}
+
 #     - name: Build
 #       run: cargo build --verbose
 #     - name: Build (serde)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Run cargo bench
       uses: actions-rs/cargo@v1
-      if: ${{ matrix.rust == 'nightly' }}
+      if: ${{ matrix.rust == 'nightly' && matrix.os == 'ubuntu-latest' && matrix.cargo_args == '' }}
       with:
         command: bench
         args: ${{ matrix.cargo_args }}


### PR DESCRIPTION
Run `cargo bench` on `nightly` compiler.
In this PR, the `nightly` compiler is only provided for `ubuntu-latest` and no `serde`.

Will fix #29