### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -942,8 +942,8 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
             //  so it's always a valid index to access.
             //  It is safe to access index 0 (i.e. `ptr`), because
             //  1 <= end < self.len(), which means self.len() >= 2.
+            let ptr = self.data.as_mut_ptr();
             unsafe {
-                let ptr = self.data.as_mut_ptr();
                 ptr::swap(ptr, ptr.add(end));
             }
             self.sift_down_range(0, end);
@@ -960,47 +960,47 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     // Using a hole reduces the constant factor compared to using swaps,
     // which involves twice as many moves.
     fn sift_up(&mut self, start: usize, pos: usize) -> usize {
-        unsafe {
+        
             // Take out the value at `pos` and create a hole.
-            let mut hole = Hole::new(&mut self.data, pos);
+            let mut hole = unsafe { Hole::new(&mut self.data, pos) };
 
             while hole.pos() > start {
                 let parent = (hole.pos() - 1) / 2;
                 // if hole.element() <= hole.get(parent) {
-                if self.cmp.compare(hole.element(), hole.get(parent)) != Ordering::Greater {
+                if self.cmp.compare(hole.element(), unsafe { hole.get(parent) }) != Ordering::Greater {
                     break;
                 }
-                hole.move_to(parent);
+                unsafe { hole.move_to(parent) };
             }
             hole.pos()
-        }
+        
     }
 
     /// Take an element at `pos` and move it down the heap,
     /// while its children are larger.
     fn sift_down_range(&mut self, pos: usize, end: usize) {
-        unsafe {
-            let mut hole = Hole::new(&mut self.data, pos);
+        
+            let mut hole = unsafe { Hole::new(&mut self.data, pos) };
             let mut child = 2 * pos + 1;
             while child < end - 1 {
                 // compare with the greater of the two children
                 // if !(hole.get(child) > hole.get(child + 1)) { child += 1 }
-                child += (self.cmp.compare(hole.get(child), hole.get(child + 1))
+                child += (self.cmp.compare(unsafe { hole.get(child) }, unsafe { hole.get(child + 1) })
                     != Ordering::Greater) as usize;
                 // if we are already in order, stop.
                 // if hole.element() >= hole.get(child) {
-                if self.cmp.compare(hole.element(), hole.get(child)) != Ordering::Less {
+                if self.cmp.compare(hole.element(), unsafe { hole.get(child) }) != Ordering::Less {
                     return;
                 }
-                hole.move_to(child);
+                unsafe { hole.move_to(child) };
                 child = 2 * hole.pos() + 1;
             }
             if child == end - 1
-                && self.cmp.compare(hole.element(), hole.get(child)) == Ordering::Less
+                && self.cmp.compare(hole.element(), unsafe { hole.get(child) }) == Ordering::Less
             {
-                hole.move_to(child);
+                unsafe { hole.move_to(child) };
             }
-        }
+        
     }
 
     fn sift_down(&mut self, pos: usize) {


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 


Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 