### PR TITLE
Bump MSRV to 1.36.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
         - macos-latest
         rust:
         - stable
-        - 1.32.0 # MSRV (Rust 2018 and rand support)
+        - 1.36.0 # MSRV (Rust 2018 and dev-dependency `serde_json`)
         cargo_args:
         - ""
         - --features serde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Bump MSRV (minimum supported rust version) to rust 1.36.0.
+
 ## [0.4.1] - 2021-01-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Other notable added methods are:
 
 ## MSRV (Minimum Supported Rust Version)
 
-This crate requires Rust 1.32.0 or later.
+This crate requires Rust 1.36.0 or later.
 
 # Changes
 


### PR DESCRIPTION
Rust 1.36.0 is required for dev-dependency `serde_json` as of 1.0.73, through its dependency `itoa`.