### PR TITLE
Migrate to Rust 2021 edition

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,18 +16,13 @@ jobs:
         - macos-latest
         rust:
         - stable
-        - 1.52.0  # MSRV
+        - 1.56.0  # MSRV
         cargo_args:
         - ""
         - --features serde
         include:
-          # Also test on nightly and Rust versions between MSRV and stable
-          # where there is conditional compilation
           - os: ubuntu-latest
             rust: nightly
-            cargo_args: ""
-          - os: ubuntu-latest
-            rust: 1.56.0
             cargo_args: ""
 
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `#[must_use]` attribute to many methods, porting and extending several
   rust-lang/rust PRs
-* Method `shrink_to()` for Rust 1.56.0 and greater, ported from rust-lang/rust
-* Implementation of `From<[T; N]>` for `BinaryHeap<T>` for Rust 1.56.0 or
-  greater, ported from rust-lang/rust#84111
+* Method `shrink_to()`, ported from rust-lang/rust
+* Implementation of `From<[T; N]>` for `BinaryHeap<T>`, ported from
+  rust-lang/rust#84111
 * Links to referenced items in the documenation
 * Example of a min-heap, ported from rust-lang/rust#60451
 * Documentation of time complexities of several methods, ported from
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Bump MSRV (minimum supported rust version) to rust 1.52.0.
+* Migrate to Rust 2021 Edition
+* Increase MSRV (minimum supported rust version) to rust 1.56.0.
 * Implement `From<BinaryHeap<T, C>>` for `Vec<T>` instead of `Into<Vec<T>>` for
   `BinaryHeap<T, C>`
 * Port rust-lang/rust#77435 improvement to rebuild heuristic of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0.116", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.57"
-rand = "0.7.3"
+rand = "0.8"
 
 [badges]
 # TODO: waiting for PR to land...: https://github.com/rust-lang/crates.io/pull/1838#

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,8 @@ repository = "https://github.com/sekineh/binary-heap-plus-rs"
 readme = "README.md"
 keywords = ["binary", "heap", "priority", "queue"]
 categories = ["data-structures", "algorithms", ]
-edition = "2018"
-
-[build-dependencies]
-autocfg = "1"
+edition = "2021"
+rust-version = "1.56.0"
 
 [dependencies]
 compare = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ This crate is based on the standard library's implementation of
 [`BinaryHeap`](https://doc.rust-lang.org/stable/std/collections/struct.BinaryHeap.html)
 from Rust 1.62.0.
 
-This crate requires Rust 1.52.0 or later.  A few of its APIs are only available
-for more recent versions of Rust where they have been stabilized in the
-standard library; see the documentation for specifics.
+The minimum supported Rust version is 1.56.0.
 
 # Changes
 

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    let ac = autocfg::new();
-
-    // Required for stabilization of `Vec::shrink_to()` and `IntoIterator` for arrays.
-    ac.emit_rustc_version(1, 56);
-
-    autocfg::rerun_path("build.rs");
-}

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -157,7 +157,7 @@ use std::slice;
 // use std::vec::Drain;
 use compare::Compare;
 use core::fmt;
-use core::mem::{size_of, swap, ManuallyDrop};
+use core::mem::{swap, ManuallyDrop};
 use core::ptr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -1008,11 +1008,9 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
 
         let tail_len = self.len() - start;
 
-        // `usize::BITS` requires Rust 1.53.0 or greater.
-        #[allow(clippy::manual_bits)]
         #[inline(always)]
         fn log2_fast(x: usize) -> usize {
-            8 * size_of::<usize>() - (x.leading_zeros() as usize) - 1
+            (usize::BITS - x.leading_zeros() - 1) as usize
         }
 
         // `rebuild` takes O(self.len()) operations

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -288,7 +288,7 @@ pub struct MaxComparator;
 
 impl<T: Ord> Compare<T> for MaxComparator {
     fn compare(&self, a: &T, b: &T) -> Ordering {
-        a.cmp(&b)
+        a.cmp(b)
     }
 }
 
@@ -300,7 +300,7 @@ pub struct MinComparator;
 
 impl<T: Ord> Compare<T> for MinComparator {
     fn compare(&self, a: &T, b: &T) -> Ordering {
-        b.cmp(&a)
+        b.cmp(a)
     }
 }
 

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -21,8 +21,6 @@
 //!
 //! ```
 //! use std::cmp::Ordering;
-//! // Only required for Rust versions prior to 1.43.0.
-//! use std::usize;
 //! use binary_heap_plus::BinaryHeap;
 //!
 //! #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1258,12 +1256,7 @@ impl<T, C> BinaryHeap<T, C> {
     /// heap.shrink_to(10);
     /// assert!(heap.capacity() >= 10);
     /// ```
-    ///
-    /// # Compatibility
-    ///
-    /// This feature requires Rust 1.56.0 or greater.
     #[inline]
-    #[cfg(rustc_1_56)]
     pub fn shrink_to(&mut self, min_capacity: usize) {
         self.data.shrink_to(min_capacity)
     }
@@ -1655,10 +1648,6 @@ impl<T: Ord> From<Vec<T>> for BinaryHeap<T> {
     }
 }
 
-/// # Compatibility
-///
-/// This trait is only implemented for Rust 1.56.0 or greater.
-#[cfg(rustc_1_56)]
 impl<T: Ord, const N: usize> From<[T; N]> for BinaryHeap<T> {
     /// ```
     /// use binary_heap_plus::BinaryHeap;

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -1106,7 +1106,7 @@ impl<T, C> BinaryHeap<T, C> {
     /// }
     /// ```
     // #[stable(feature = "rust1", since = "1.0.0")]
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.data.iter(),
         }

--- a/src/binary_heap.rs
+++ b/src/binary_heap.rs
@@ -225,6 +225,15 @@ use std::vec;
 /// assert!(heap.is_empty())
 /// ```
 ///
+/// A `BinaryHeap` with a known list of items can be initialized from an array:
+///
+/// ```
+/// use binary_heap_plus::BinaryHeap;
+///
+/// // This will create a max-heap.
+/// let heap = BinaryHeap::from([1, 5, 2]);
+/// ```
+///
 /// ## Min-heap
 ///
 /// `BinaryHeap` can also act as a min-heap without requiring [`Reverse`] or a custom [`Ord`]
@@ -685,7 +694,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     ///
     /// // replace the comparor
     /// heap.replace_cmp(Comparator { ascending: false });
-    /// assert_eq!(heap.into_iter_sorted().collect::<Vec<_>>(), vec![5, 3, 1]);
+    /// assert_eq!(heap.into_iter_sorted().collect::<Vec<_>>(), [5, 3, 1]);
     /// ```
     #[inline]
     pub fn replace_cmp(&mut self, cmp: C) {
@@ -755,7 +764,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let mut heap = BinaryHeap::from(vec![1, 3]);
+    /// let mut heap = BinaryHeap::from([1, 3]);
     ///
     /// assert_eq!(heap.pop(), Some(3));
     /// assert_eq!(heap.pop(), Some(1));
@@ -828,7 +837,7 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     /// ```
     /// use binary_heap_plus::BinaryHeap;
     ///
-    /// let mut heap = BinaryHeap::from(vec![1, 2, 4, 5, 7]);
+    /// let mut heap = BinaryHeap::from([1, 2, 4, 5, 7]);
     /// heap.push(6);
     /// heap.push(3);
     ///
@@ -1057,8 +1066,8 @@ impl<T, C: Compare<T>> BinaryHeap<T, C> {
     /// ```
     /// use binary_heap_plus::BinaryHeap;
     ///
-    /// let mut a = BinaryHeap::from(vec![-10, 1, 2, 3, 3]);
-    /// let mut b = BinaryHeap::from(vec![-20, 5, 43]);
+    /// let mut a = BinaryHeap::from([-10, 1, 2, 3, 3]);
+    /// let mut b = BinaryHeap::from([-20, 5, 43]);
     ///
     /// a.append(&mut b);
     ///
@@ -1089,7 +1098,7 @@ impl<T, C> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let heap = BinaryHeap::from(vec![1, 2, 3, 4]);
+    /// let heap = BinaryHeap::from([1, 2, 3, 4]);
     ///
     /// // Print 1, 2, 3, 4 in arbitrary order
     /// for x in heap.iter() {
@@ -1112,9 +1121,9 @@ impl<T, C> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let heap = BinaryHeap::from(vec![1, 2, 3, 4, 5]);
+    /// let heap = BinaryHeap::from([1, 2, 3, 4, 5]);
     ///
-    /// assert_eq!(heap.into_iter_sorted().take(2).collect::<Vec<_>>(), vec![5, 4]);
+    /// assert_eq!(heap.into_iter_sorted().take(2).collect::<Vec<_>>(), [5, 4]);
     /// ```
     // #[unstable(feature = "binary_heap_into_iter_sorted", issue = "59278")]
     pub fn into_iter_sorted(self) -> IntoIterSorted<T, C> {
@@ -1268,7 +1277,7 @@ impl<T, C> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let heap = BinaryHeap::from(vec![1, 2, 3, 4, 5, 6, 7]);
+    /// let heap = BinaryHeap::from([1, 2, 3, 4, 5, 6, 7]);
     /// let vec = heap.into_vec();
     ///
     /// // Will print in some order
@@ -1290,7 +1299,7 @@ impl<T, C> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let heap = BinaryHeap::from(vec![1, 3]);
+    /// let heap = BinaryHeap::from([1, 3]);
     ///
     /// assert_eq!(heap.len(), 2);
     /// ```
@@ -1337,7 +1346,7 @@ impl<T, C> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let mut heap = BinaryHeap::from(vec![1, 3]);
+    /// let mut heap = BinaryHeap::from([1, 3]);
     ///
     /// assert!(!heap.is_empty());
     ///
@@ -1363,7 +1372,7 @@ impl<T, C> BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let mut heap = BinaryHeap::from(vec![1, 3]);
+    /// let mut heap = BinaryHeap::from([1, 3]);
     ///
     /// assert!(!heap.is_empty());
     ///
@@ -1693,7 +1702,7 @@ impl<T, C> IntoIterator for BinaryHeap<T, C> {
     ///
     /// ```
     /// use binary_heap_plus::BinaryHeap;
-    /// let heap = BinaryHeap::from(vec![1, 2, 3, 4]);
+    /// let heap = BinaryHeap::from([1, 2, 3, 4]);
     ///
     /// // Print 1, 2, 3, 4 in arbitrary order
     /// for x in heap.into_iter() {


### PR DESCRIPTION
Resolves #37.

This migrates the crate to the Rust 2021 edition and increases the MSRV to 1.56.0, [as discussed in #34](https://github.com/sekineh/binary-heap-plus-rs/pull/34#issuecomment-1250184976).

Now that Rust 1.56.0 is required, we can remove `build.rs` and the remaining uses of conditional compilation.  We also port two more changes from `std` that were not part of #34  because of version requirements:
- Use `usize::BITS` instead of `8 * std::mem::size_of::<usize>()`.
- Use arrays instead of vectors in documentation examples when creating binary heaps from lists of known values.

Finally, while not exactly related to the edition migration, this PR includes a few other small fixes:
- Update dev-dependency `rand` to version 0.8.x.
- Fix a clippy warning.
- Fix an elided lifetimes lint that was overlooked in #34.